### PR TITLE
Finally handling retireJS output accurately

### DIFF
--- a/server/services/retirejs/retire.js
+++ b/server/services/retirejs/retire.js
@@ -6,9 +6,19 @@ var retireScan = function(dir) {
   var results = childProcess.spawnSync('retire', [ '--outputformat', 'json'], {encoding: 'utf8', cwd: dir});
 
   // returning either the 2nd or 3rd item in the results array (2nd should be STDOUT, 3rd should be STDERR)
-  var output = results.output[2] ? results.output[2] : results.output[1];
+  var output;
+  if (results) {
+    output = results.output[2] ? results.output[2] : results.output[1];
+  } else {
+    output = null;
+  }
+  // if output isn't an array make it null (the text isn't helpful)
+  if (JSON.parse(output).length < 1) {
+    output = null; 
+  }
+  // returning either the 2nd or 3rd item in the results array (2nd should be STDOUT, 3rd should be STDERR)
   console.log('retireJS output: ', output);
-  return output ? output: null;
+  return output;
 };
 
 


### PR DESCRIPTION
HTTPS has been launched on the server, it's available at www.gitsecure.me.

This change adds the handling we needed to get back retireJS results accurately (after a ton of debugging w/ Camille)

Everything seems to be working, and there are basically four cases for each scan:
- IF the results for any of the scans is just an empty object {}, then the scans haven't finished, so we want to show that they're still in progress
- IF there is an object with an 'error' property, then that particular scan failed
- IF there is an object with a 'clear' property, then that particular scan ran successfully with no results
- IF there's anything else, they are results from the scan.

If you want an example repo with some retireJS results I used [angular-google-maps](https://github.com/angular-ui/angular-google-maps)
